### PR TITLE
Added fix for Circulation swiped ID Cards.

### DIFF
--- a/app/assets/javascripts/admin_shortcuts.js.coffee
+++ b/app/assets/javascripts/admin_shortcuts.js.coffee
@@ -100,6 +100,7 @@ class AdminShortcutsManager
     @user_field.removeClass("bordered")
     user_query = @user_field.val()
     return if !user_query || user_query == ""
+    user_query = user_query.replace(/^11([0-9]{9})/, '$1')
     @user_field.val("")
     @user_field.focus()
     this.load_user(user_query)

--- a/spec/features/staff_shortcuts_spec.rb
+++ b/spec/features/staff_shortcuts_spec.rb
@@ -61,6 +61,17 @@ describe "staff shortcuts" do
           expect(page).to have_content("User Reservations (#{user.onid})")
         end
       end
+      context "and it is a card swiped ID" do
+        let(:value) do
+          banner_record
+          "11931590800"
+        end
+        it "should bring up a modal window" do
+          within("#modal_skeleton") do
+            expect(page).to have_content("User Reservations (#{user.onid})")
+          end
+        end
+      end
       context "and the user has a reservation" do
         let(:reservation) {create(:reservation, :user_onid => user.onid, :start_time => Time.current + 2.hours, :end_time => Time.current+4.hours)}
         it "should show it" do


### PR DESCRIPTION
This fix is very specific to OSU, but if the ID card swiped doesn't start with 11 and isn't nine characters it just won't do anything.

Closes #143
