### PR TITLE
Suppress exception from sending email when redis server is not available

### DIFF
--- a/app/services/canceller.rb
+++ b/app/services/canceller.rb
@@ -36,7 +36,11 @@ class Canceller
     reserved_for = UserDecorator.new(User.new(reservation.user_onid))
     reserved_for = cancelling_user if reserved_for.onid == cancelling_user.onid
     unless reserved_for.email.blank?
-      ReservationMailer.delay.cancellation_email(reservation, reserved_for)
+      begin
+        ReservationMailer.delay.cancellation_email(reservation, reserved_for)
+      rescue Redis::CannotConnectError
+        return
+      end
     end
   end
 

--- a/app/services/reserver.rb
+++ b/app/services/reserver.rb
@@ -63,7 +63,11 @@ class Reserver
   def send_email
     return if @options[:ignore_email]
     unless user.email.blank?
-      ReservationMailer.delay.send(email_method, reservation, user.decorate)
+      begin
+        ReservationMailer.delay.send(email_method, reservation, user.decorate)
+      rescue Redis::CannotConnectError
+        return
+      end
     end
   end
 


### PR DESCRIPTION
Not sure if it's enough to only kill the exception. Close #173 
