### PR TITLE
update hours_manager to handle no closing option

### DIFF
--- a/app/models/event_manager/hours_manager.rb
+++ b/app/models/event_manager/hours_manager.rb
@@ -37,6 +37,8 @@ class EventManager::HoursManager < EventManager::EventManager
     elsif api_result['open_all_day'].present? && api_result['open_all_day']
       api_result['open'] = '12:00 am'
       api_result['close'] = '12:00 am'
+    elsif api_result['close'] == '11:59pm'
+      api_result['close'] = '12:15 am'
     end
     api_result
   end


### PR DESCRIPTION
fixes #337 

It turns out that `12:15 am` for `close` time means `no closing` according to the hours_manager spec: https://github.com/osulp/Room-Reservation/blob/master/spec/models/event_manager/hours_manager_spec.rb#L132

In alma, we use `11:59pm` when no closing, so this adds a new case to `fix_api_hours`.

