### PR TITLE
pull additional open/close hour block from hours API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,3 +103,5 @@ group :test do
   gem 'coveralls', require: false
   gem 'rspec_junit_formatter'
 end
+
+gem "byebug", "~> 11.0", :groups => [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
     bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
     builder (3.2.3)
+    byebug (11.0.1)
     callsite (0.0.11)
     cancan (1.6.10)
     capistrano (2.15.9)
@@ -397,6 +398,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootstrap-sass (~> 2.3.0)
+  byebug (~> 11.0)
   cancan
   capistrano (~> 2.14)
   capybara

--- a/app/models/event_manager/cleaning_records_manager.rb
+++ b/app/models/event_manager/cleaning_records_manager.rb
@@ -5,7 +5,29 @@ class EventManager::CleaningRecordsManager < EventManager::EventManager
   end
 
   def get_events
-    range_cleaning_records(start_time, end_time).map{|x| to_event(x)}.flatten
+    records = range_cleaning_records(start_time, end_time).map{|x| to_event(x)}.flatten
+
+    # Note: after getting the events, add Events::CleaningEvent to fill in the
+    # blocks for multiple closing blocks. Given a start_time date, for each
+    # room in floors 1, 2 and 5, add a CleaningRecord without persisting
+    # it to automatically add a close block for this additional
+    # open/close block. This only works for one additional open/close
+    # block for now.
+    start_date = start_time.strftime('%Y-%m-%d')
+    hours_manager = EventManager::HoursManager.new
+    open_hours = hours_manager.hours(start_date)
+    if open_hours['all_open_hours'].count > 1
+      Room.where(floor: [1,2,5]).each do |room|
+        tmp_close_time = Time.parse(open_hours['all_open_hours'].first['close']).strftime('%H:%M:%S')
+        tmp_open_time = Time.parse(open_hours['all_open_hours'].last['open']).strftime('%H:%M:%S')
+        tmp_start_time = Time.zone.parse("#{start_date} #{tmp_close_time}")
+        tmp_end_time = Time.zone.parse("#{start_date} #{tmp_open_time}")
+        attributes = {id: rand(DateTime.now.to_i), start_date: "#{start_date}", end_date: "#{start_date}", start_time: "#{tmp_start_time}", end_time: "#{tmp_end_time}"}
+        cleaning_record = CleaningRecord.new(attributes)
+        records << Events::CleaningEvent.new(tmp_start_time, tmp_end_time, 0, cleaning_record, room.id)
+      end
+    end
+    records
   end
 
   def cache_key(start_time, end_time,rooms=[])

--- a/app/models/event_manager/hours_manager.rb
+++ b/app/models/event_manager/hours_manager.rb
@@ -34,6 +34,13 @@ class EventManager::HoursManager < EventManager::EventManager
     if api_result['event_status'].casecmp('close').zero?
       api_result['open'] = '1:00 am'
       api_result['close'] = '1:00 am'
+    elsif api_result['all_open_hours'].count > 1
+      api_result['open'] = Time.parse(api_result['all_open_hours'].first['open']).strftime('%-l:%M %P')
+      if api_result['all_open_hours'].last['close'] == '23:59'
+        api_result['close'] = '12:00 am'
+      else
+        api_result['close'] = Time.parse(api_result['all_open_hours'].last['close']).strftime('%-l:%M %P')
+      end
     elsif api_result['open_all_day'].present? && api_result['open_all_day']
       api_result['open'] = '12:00 am'
       api_result['close'] = '12:00 am'


### PR DESCRIPTION
fixes https://github.com/osulp/Room-Reservation/issues/339

- This update gets the additional open/close hours from `api_result['all_open_hours']`, which returns all the open/close hours (due to temporary closing for limited services) during these times. 
- To add additional hours, the CleaningRecordsManager is extended to use these additional hours and instantiate blocks on the fly (without having them in the database) to render a gray block with Closed status, so it now depends on the API results instead of CleaningRecord entries in the database (workaround currently in production).

Screenshots:

![image](https://user-images.githubusercontent.com/3486120/71633212-b85fe500-2bc7-11ea-90ed-4fd5c7780098.png)
![image](https://user-images.githubusercontent.com/3486120/71633217-c1e94d00-2bc7-11ea-954a-1b3dd34d3e1e.png)
